### PR TITLE
CSS fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,3 @@ See the example-site directory for a minimal working example.
 
 ## Todo List
 * Menu is not correctly displayed when Doxygen sidebar is enabled.
-* Class index is incorrectly displayed.

--- a/customdoxygen.css
+++ b/customdoxygen.css
@@ -13,6 +13,12 @@ font-size: 1.15em !important;
 .navbar{
  border: 0px solid #222 !important;
 }
+table{
+    white-space:pre-wrap !important;
+}
+/*
+ ===========================
+ */
 
 
 /* Sticky footer styles
@@ -142,8 +148,8 @@ div.fragment {
 }
 
 div.line {
-    font-family: monospace, fixed;
-    font-size: 13px;
+    font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+    font-size: 12px;
     min-height: 13px;
     line-height: 1.0;
     text-wrap: unrestricted;
@@ -151,7 +157,7 @@ div.line {
     white-space: -pre-wrap;     /* Opera 4-6 */
     white-space: -o-pre-wrap;   /* Opera 7 */
     white-space: pre-wrap;      /* CSS3  */
-    word-wrap: break-word;      /* IE 5.5+ */
+    word-wrap: normal;      /* IE 5.5+ */
     text-indent: -53px;
     padding-left: 53px;
     padding-bottom: 0px;
@@ -167,6 +173,9 @@ div.line {
     transition-property: background-color, box-shadow;
     transition-duration: 0.5s;
 }
+div.line:hover{
+    background-color: #FBFF00;
+}
 
 div.line.glow {
     background-color: cyan;
@@ -177,16 +186,21 @@ div.line.glow {
 span.lineno {
     padding-right: 4px;
     text-align: right;
-    border-right: 2px solid #0F0;
-    background-color: #E8E8E8;
+    color:rgba(0,0,0,0.3);
+    border-right: 1px solid #EEE;
+    border-left: 1px solid #EEE;
+    background-color: #FFF;
     white-space: pre;
+    font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace ;
 }
 span.lineno a {
-    background-color: #D8D8D8;
+    background-color: #FAFAFA;
+    cursor:pointer;
 }
 
 span.lineno a:hover {
-    background-color: #C8C8C8;
+    background-color: #EFE200;
+    color: #1e1e1e;
 }
 
 div.groupHeader {
@@ -318,7 +332,10 @@ span.SRScope {
 
 .table > tbody > tr > td.memSeparator {
   line-height: 0;
+  .table-hover;
+
 }
+
 .memItemLeft, .memTemplItemLeft {
   white-space: normal;
 }

--- a/doxy-boot.js
+++ b/doxy-boot.js
@@ -53,8 +53,8 @@ $( document ).ready(function() {
     $("div.ttname a").css("color", 'white');
     $("div.ttdef,div.ttdoc,div.ttdeci").addClass("panel-body");
 
-    $('div.fragment.well div.line:first').css('margin-top', '15px');
-    $('div.fragment.well div.line:last').css('margin-bottom', '15px');
+    $('div.fragment.well div.line:first').css('margin-top', '2px');
+    $('div.fragment.well div.line:last').css('margin-bottom', '2px');
 
 	$('table.doxtable').removeClass('doxtable').addClass('table table-striped table-bordered').each(function(){
 		$(this).prepend('<thead></thead>');
@@ -87,8 +87,59 @@ $( document ).ready(function() {
 		if(getOriginalWidthOfImg($(this)[0]) > $('#content>div.container').width())
 			$(this).css('width', '100%');
 	});
+	$("div.headertitle").addClass("page-header");
+	$("div.title").addClass("h1");
+	
+	$('li > a[href="index.html"] > span').before("<i class='fa fa-cog'></i> ");
+	//$('li > a[href="index.html"] > span').text("CoActionOS");
+	$('li > a[href="modules.html"] > span').before("<i class='fa fa-square'></i> ");
+	$('li > a[href="namespaces.html"] > span').before("<i class='fa fa-bars'></i> ");
+	$('li > a[href="annotated.html"] > span').before("<i class='fa fa-list-ul'></i> ");
+	$('li > a[href="classes.html"] > span').before("<i class='fa fa-book'></i> ");
+	$('li > a[href="inherits.html"] > span').before("<i class='fa fa-sitemap'></i> ");
+	$('li > a[href="functions.html"] > span').before("<i class='fa fa-list'></i> ");
+	$('li > a[href="functions_func.html"] > span').before("<i class='fa fa-list'></i> ");
+	$('li > a[href="functions_vars.html"] > span').before("<i class='fa fa-list'></i> ");
+	$('li > a[href="functions_enum.html"] > span').before("<i class='fa fa-list'></i> ");
+	$('li > a[href="functions_eval.html"] > span').before("<i class='fa fa-list'></i> ");
+	$('img[src="ftv2ns.png"]').replaceWith('<span class="label label-danger">N</span> ');
+	$('img[src="ftv2cl.png"]').replaceWith('<span class="label label-danger">C</span> ');
+	
+	$("ul.tablist").addClass("nav nav-pills nav-justified");
+	$("ul.tablist").css("margin-top", "0.5em");
+	$("ul.tablist").css("margin-bottom", "0.5em");
+	$("li.current").addClass("active");
+	$("iframe").attr("scrolling", "yes");
+	
+	$("#nav-path > ul").addClass("breadcrumb");
+	
+	$("table.params").addClass("table");
+	$("div.ingroups").wrapInner("<small></small>");
+	$("div.levels").css("margin", "0.5em");
+	$("div.levels > span").addClass("btn btn-default btn-xs");
+	$("div.levels > span").css("margin-right", "0.25em");
+	
+	$("table.directory").addClass("table table-striped");
+	$("div.summary > a").addClass("btn btn-default btn-xs");
+	$("table.fieldtable").addClass("table");
+	$(".fragment").addClass("well");
+	$(".memitem").addClass("panel panel-default");
+	$(".memproto").addClass("panel-heading");
+	$(".memdoc").addClass("panel-body");
+	$("span.mlabel").addClass("label label-info");
+	
+	$("table.memberdecls").addClass("table");
+	$("[class^=memitem]").addClass("active");
+	
+	$("div.ah").addClass("btn btn-default");
+	$("span.mlabels").addClass("pull-right");
+	$("table.mlabels").css("width", "100%")
+	$("td.mlabels-right").addClass("pull-right");
 
-
+	$("div.ttc").addClass("panel panel-info");
+	$("div.ttname").addClass("panel-heading");
+	$("div.ttdef,div.ttdoc,div.ttdeci").addClass("panel-body");
+//    $("table").addClass("table table-stripped");
   /* responsive search box */
 
   $('#MSearchBox').parent().remove();

--- a/example-site/Doxyfile
+++ b/example-site/Doxyfile
@@ -1068,7 +1068,7 @@ ALPHABETICAL_INDEX     = YES
 # Minimum value: 1, maximum value: 20, default value: 5.
 # This tag requires that the tag ALPHABETICAL_INDEX is set to YES.
 
-COLS_IN_ALPHA_INDEX    = 5
+COLS_IN_ALPHA_INDEX    = 2
 
 # In case all classes in a project start with a common prefix, all classes will
 # be put under the same header in the alphabetical index. The IGNORE_PREFIX tag

--- a/example-site/header.html
+++ b/example-site/header.html
@@ -20,7 +20,7 @@
         $mathjax
         <link href="$relpath^$stylesheet" rel="stylesheet" type="text/css" />
         $extrastylesheet
-
+        <link href='https://fonts.googleapis.com/css?family=Roboto+Slab' rel='stylesheet' type='text/css'>
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
         <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
         <script type="text/javascript" src="$relpath^doxy-boot.js"></script>
@@ -37,6 +37,6 @@
             <div class="content" id="content">
                 <div class="container">
                     <div class="row">
-                        <div class="col-sm-12 panel panel-default" style="padding-bottom: 15px;">
+                        <div class="col-sm-12 panel " style="padding-bottom: 15px;">
                             <div style="margin-bottom: 15px;">
 <!-- end header part -->


### PR DESCRIPTION
Just some changes that were made for our doxygen docs, to fix a few quirks.

Better CSS for Source Code pages to resemble GitHub Source Code view.
- Consolas Font
- Line no. foreground/background changed to resemble github.
- Hover highlight for better readability

Container Div is no longer in borderd box --> See header.html diff

CSS & DoxyFile changes for better Class Index view.

doxy-boot.js
- Added for bootstrap stripped table.