### PR TITLE
change div.ingroups from <small> to <span class='text-nowrap'>

### DIFF
--- a/doxy-boot.js
+++ b/doxy-boot.js
@@ -26,7 +26,7 @@ $( document ).ready(function() {
     $("#nav-path > ul").addClass("breadcrumb");
 
     $("table.params").addClass("table");
-    $("div.ingroups").wrapInner("<small></small>");
+    $("div.ingroups").wrapInner("<span class='text-nowrap'></span>");
     $("div.levels").css("margin", "0.5em");
     $("div.levels > span").addClass("btn btn-default btn-xs");
     $("div.levels > span").css("margin-right", "0.25em");
@@ -92,8 +92,8 @@ $( document ).ready(function() {
 		if(getOriginalWidthOfImg($(this)[0]) > $('#content>div.container').width())
 			$(this).css('width', '100%');
 	});
-	
-  
+
+
   /* responsive search box */
   $('#MSearchBox').parent().remove();
 


### PR DESCRIPTION
`div.ingroups` has already a small text size and doesn't need the additional `<small>` tag.
The problem occurs in the presence of doxygen sub-modules.
In this example `BoCA>>Generic` is unreadable small

![old](https://cloud.githubusercontent.com/assets/13359942/18125672/0d5be0b4-6faa-11e6-9ba4-f82492fac9aa.png)

with the fix the text size is reasonable

![new](https://cloud.githubusercontent.com/assets/13359942/18125674/10ce5254-6faa-11e6-89ca-74cc2801b098.png)

the additional class `text-nowrap` is necessary, because otherwise the list would be splittet into three lines.
Sorry for the change in white space.