### PR TITLE
Fix formatting of template type parameters

### DIFF
--- a/doxy-boot.js
+++ b/doxy-boot.js
@@ -26,6 +26,7 @@ $( document ).ready(function() {
     $("#nav-path > ul").addClass("breadcrumb");
 
     $("table.params").addClass("table");
+    $("table.tparams").addClass("table");
     $("div.ingroups").wrapInner("<span class='text-nowrap'></span>");
     $("div.levels").css("margin", "0.5em");
     $("div.levels > span").addClass("btn btn-default btn-xs");


### PR DESCRIPTION
The class of the table for template type parameters is "tparams". This ensures such tables are formatted properly (in the same way as those for regular parameters).